### PR TITLE
set socket option SO_RCVTIMEO

### DIFF
--- a/MinecraftQuery_Simple.php
+++ b/MinecraftQuery_Simple.php
@@ -14,6 +14,7 @@
 		$Socket = Socket_Create( AF_INET, SOCK_STREAM, SOL_TCP );
 		
 		Socket_Set_Option( $Socket, SOL_SOCKET, SO_SNDTIMEO, array( 'sec' => (int)$Timeout, 'usec' => 0 ) );
+		Socket_Set_Option( $Socket, SOL_SOCKET, SO_RCVTIMEO, array( 'sec' => (int)$Timeout, 'usec' => 0 ) );
 		
 		if( $Socket === FALSE || @Socket_Connect( $Socket, $IP, (int)$Port ) === FALSE )
 		{


### PR DESCRIPTION
Added socket option SO_RCVTIMEO, this shortened timeouts in my application to reasonable periods when querying non-responsive Minecraft servers.
