### PR TITLE
Receive length change

### DIFF
--- a/MinecraftQuery_Simple.php
+++ b/MinecraftQuery_Simple.php
@@ -22,7 +22,7 @@
 		}
 		
 		Socket_Send( $Socket, "\xFE\x01", 2, 0 );
-		$Len = Socket_Recv( $Socket, $Data, 256, 0 );
+		$Len = Socket_Recv( $Socket, $Data, 512, 0 );
 		Socket_Close( $Socket );
 		
 		if( $Len < 4 || $Data[ 0 ] !== "\xFF" )


### PR DESCRIPTION
Adjusted receive length from 256 to 512 to accommodate mega cloud servers with 10,000+ slots that were giving zero player counts. 
