### PR TITLE
Read more bytes

### DIFF
--- a/MinecraftQuery.class.php
+++ b/MinecraftQuery.class.php
@@ -173,7 +173,7 @@ class MinecraftQuery
 			throw new MinecraftQueryException( "Failed to write on socket." );
 		}
 		
-		$Data = FRead( $this->Socket, 2048 );
+		$Data = FRead( $this->Socket, 4096 );
 		
 		if( $Data === false )
 		{


### PR DESCRIPTION
A friend only gets 17 players with the udp query. I think we should read more bytes from the socket to show more players.
