### PR TITLE
Add 'game_id' to the list of recognised properties from full statuses

### DIFF
--- a/MinecraftQuery.class.php
+++ b/MinecraftQuery.class.php
@@ -110,7 +110,7 @@ class MinecraftQuery
 			'numplayers' => 'Players',
 			'maxplayers' => 'MaxPlayers',
 			'hostport'   => 'HostPort',
-			'hostip'     => 'HostIp'
+			'hostip'     => 'HostIp',
 			'game_id'    => 'GameName'
 		);
 		


### PR DESCRIPTION
Current Minecraft server queries support 'game_id' in the status result, which is not currently supported in PHP-Minecraft-Query.

This branch adds that one key.
