### PR TITLE
Missing required exception classes

### DIFF
--- a/view.php
+++ b/view.php
@@ -13,6 +13,7 @@
 	Ini_Set( 'display_errors', true );
 
 	require __DIR__ . '/src/MinecraftQuery.php';
+	require __DIR__ . '/src/MinecraftQueryException.php';
 
 	$Timer = MicroTime( true );
 

--- a/view_serverping.php
+++ b/view_serverping.php
@@ -13,6 +13,7 @@
 	Ini_Set( 'display_errors', true );
 
 	require __DIR__ . '/src/MinecraftPing.php';
+	require __DIR__ . '/src/MinecraftPingException.php';
 
 	$Timer = MicroTime( true );
 


### PR DESCRIPTION
Both examples are missing a the required exception classes

see https://github.com/xPaw/PHP-Minecraft-Query/issues/92