### PR TITLE
Add SRV lookup support (Fixes #34)

### DIFF
--- a/src/MinecraftPing.php
+++ b/src/MinecraftPing.php
@@ -31,11 +31,16 @@ class MinecraftPing
 	private $ServerPort;
 	private $Timeout;
 
-	public function __construct( $Address, $Port = 25565, $Timeout = 2 )
+	public function __construct( $Address, $Port = 25565, $Timeout = 2, $SRV = true )
 	{
 		$this->ServerAddress = $Address;
 		$this->ServerPort = (int)$Port;
 		$this->Timeout = (int)$Timeout;
+
+		if ( $SRV )
+		{
+		    $this->ResolveSRV();
+		}
 
 		$this->Connect( );
 	}
@@ -209,5 +214,28 @@ class MinecraftPing
 		}
 
 		return $i;
+	}
+
+	private function ResolveSRV( )
+	{
+	    if ( ip2long($this->ServerAddress) !== FALSE )
+	    {
+		//server address is an ip - we cannot resolve ip
+		return;
+	    }
+
+	    $result = dns_get_record('_minecraft._tcp.' . $this->ServerAddress, DNS_SRV);
+	    if ( count($result) > 0 )
+	    {
+		if ( isset($result[0]['target']) )
+		{
+		    $this->ServerAddress = $result[0]['target'];
+		}
+
+		if ( isset($result[0]['port']) )
+		{
+		    $this->ServerPort = $result[0]['port'];
+		}
+	    }
 	}
 }


### PR DESCRIPTION
The code is mainly based on @Bobcat00 suggestion. I removed the A record resolve, because some networks will then return a different motd. This motd contains a message that we should use the domain instead of the IP.

I tested the code against mineplex (mineplex.com) and hypixel (hypixel.net). It doesn't work without the changes I made although us.mineplex.com and mc.hypixel.net does, but with the changes it works in both ways.
