### PR TITLE
Rethrow existing exception

### DIFF
--- a/src/MinecraftQuery.php
+++ b/src/MinecraftQuery.php
@@ -51,7 +51,7 @@ class MinecraftQuery
 		{
 			FClose( $this->Socket );
 
-			throw new MinecraftQueryException( $e->getMessage( ) );
+			throw $e;
 		}
 
 		FClose( $this->Socket );


### PR DESCRIPTION
Instead of creating a new MinecraftQueryException, rethrow the given exception so that subclasses of MinecraftQueryException can still come through. 

It also foregoes creating a new exception Object :)