### PR TITLE
Mute errors in dns_get_record

### DIFF
--- a/src/MinecraftPing.php
+++ b/src/MinecraftPing.php
@@ -225,9 +225,9 @@ class MinecraftPing
 			return;
 		}
 
-		$Record = dns_get_record( '_minecraft._tcp.' . $this->ServerAddress, DNS_SRV );
+		$Record = @dns_get_record( '_minecraft._tcp.' . $this->ServerAddress, DNS_SRV );
 
-		if( empty( $Record ) )
+		if( !$Record || empty( $Record ) )
 		{
 			return;
 		}


### PR DESCRIPTION
Hi, I'm using latest PHP 7.3, and this exception is very rare and random, but it happenes when PHP is updating a lot of servers.

ErrorException: dns_get_record(): A temporary server error occurred.

It appears that this exception can't be caught, it's some bug in PHP (https://bugs.php.net/bug.php?id=73149&thanks=6) so I muted exceptions in dns_get_record and add check for bool(false).

Last time it happened with host mc.splaycz.tk and port 25565.