### PR TITLE
Fix waarning when response is empty

### DIFF
--- a/src/MinecraftQuery.php
+++ b/src/MinecraftQuery.php
@@ -220,7 +220,7 @@ class MinecraftQuery
 			throw new MinecraftQueryException( "Failed to read from socket." );
 		}
 
-		if( $Data[ 0 ] !== "\x1C" ) // DefaultMessageIDTypes::ID_UNCONNECTED_PONG
+		if( isset($Data[ 0 ]) && $Data[ 0 ] !== "\x1C" ) // DefaultMessageIDTypes::ID_UNCONNECTED_PONG
 		{
 			throw new MinecraftQueryException( "First byte is not ID_UNCONNECTED_PONG." );
 		}


### PR DESCRIPTION
Description of the warning
> Uninitialized string offset 0 in \vendor\xpaw\php-minecraft-query\src\MinecraftQuery.php on line 223

Ip ping : offline server

Added a check to see if the string is not empty