### PR TITLE
Combine handshake with status ping packet

### DIFF
--- a/src/MinecraftPing.php
+++ b/src/MinecraftPing.php
@@ -90,8 +90,7 @@ class MinecraftPing
 
 		$Data = Pack( 'c', StrLen( $Data ) ) . $Data; // prepend length of packet ID + data
 
-		fwrite( $this->Socket, $Data ); // handshake
-		fwrite( $this->Socket, "\x01\x00" ); // status ping
+		fwrite( $this->Socket, $Data . "\x01\x00" ); // handshake followed by status ping
 
 		$Length = $this->ReadVarInt( ); // full packet length
 


### PR DESCRIPTION
Combining both packets in the same packet is safe and also slightly reduces the amount of time required to ping the server by avoiding another round-trip to send another packet, as long as the receiving server handles packet framing correctly. I use a similar technique in Velocity without issues.