### PR TITLE
Clear plugins key for query

### DIFF
--- a/src/MinecraftQuery.php
+++ b/src/MinecraftQuery.php
@@ -187,6 +187,10 @@ class MinecraftQuery
 			{
 				$Info[ 'Plugins' ] = \explode( "; ", $Data[ 1 ] );
 			}
+			else
+			{
+				$Info[ 'Plugins' ] = '';
+			}
 		}
 		else
 		{


### PR DESCRIPTION
When pinging a bukkit derivate server without plugins the key show the software instead of being empty.