### PR TITLE
Decode motd from query properly

### DIFF
--- a/src/MinecraftQuery.php
+++ b/src/MinecraftQuery.php
@@ -166,7 +166,7 @@ class MinecraftQuery
 			}
 			else if( $Last != false )
 			{
-				$Info[ $Last ] = \mb_convert_encoding( $Value, 'UTF-8' );
+				$Info[ $Last ] = \mb_convert_encoding( $Value, 'UTF-8', 'ISO-8859-1' );
 			}
 		}
 


### PR DESCRIPTION
The query protocol doesn't support proper UTF-8 string and instead write ISO-8859-1 strings. This should fix issues with '§', 'é' and other characters that are not in the ascii range since mb_convert_encoding "from_encoding" value is not fixed here.